### PR TITLE
fixed hardcoded Prev/Next translation

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -73,11 +73,11 @@
 
   <div class="episode-footer">
     {{ with $paginator.Prev -}}
-    <div class="episode-nav-prev"><a href="{{ .URL }}"><i class="fas fa-chevron-left"></i>Prev</a>
+    <div class="episode-nav-prev"><a href="{{ .URL }}"><i class="fas fa-chevron-left"></i>{{ T "prevPage" }}</a>
     </div>
     {{- end }}
     {{ with $paginator.Next -}}
-    <div class="episode-nav-next"><a href="{{ .URL }}">Next<i class="fas fa-chevron-right"></i></a>
+    <div class="episode-nav-next"><a href="{{ .URL }}">{{ T "nextPage" }}<i class="fas fa-chevron-right"></i></a>
     </div>
     {{- end }}
   </div>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -70,11 +70,11 @@
 
   <div class="episode-footer">
     {{ with $paginator.Prev -}}
-    <div class="episode-nav-prev"><a href="{{ .URL }}"><i class="fas fa-chevron-left"></i>Prev</a>
+    <div class="episode-nav-prev"><a href="{{ .URL }}"><i class="fas fa-chevron-left"></i>{{ T "prevPage" }}</a>
     </div>
     {{- end }}
     {{ with $paginator.Next -}}
-    <div class="episode-nav-next"><a href="{{ .URL }}">Next<i class="fas fa-chevron-right"></i></a>
+    <div class="episode-nav-next"><a href="{{ .URL }}">{{ T "nextPage" }}<i class="fas fa-chevron-right"></i></a>
     </div>
     {{- end }}
   </div>


### PR DESCRIPTION
During translation this theme (*see also #1*) - I stumbled upon two hardcoded translations of *Prev* and *Next*. I replaced them with the proper variables in the translatons. Hope this helps!

Thanks for your great work! 👍🏻 